### PR TITLE
Allow specifying hoverfly startup timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       hoverfly:
-        image: spectolabs/hoverfly:v1.3.6
+        image: spectolabs/hoverfly:v1.3.7
         ports:
           - 8500:8500
           - 8888:8888

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.4] - 2023-01-28
+### Changed
+- Allow specifying hoverfly startup timeout
+- Increased default hoverfly startup timeout
+
+## [5.0.3] - 2022-08-31
+### Changed
+- Bumped default Hoverfly image to 1.3.7 to support Apple silicon
+
 ## [5.0.2] - 2022-03-28
 ### Changed
 - Bumped default Hoverfly image to 1.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.0.4] - 2023-01-28
 ### Changed
 - Allow specifying hoverfly startup timeout
-- Increased default hoverfly startup timeout
 
 ## [5.0.3] - 2022-08-31
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest_hoverfly"
-version = "5.0.3"
+version = "5.0.4"
 description = "Simplify working with Hoverfly from pytest"
 authors = ["Devops team at Wrike <devops@team.wrike.com>"]
 repository = "https://github.com/wrike/pytest-hoverfly"
@@ -21,9 +21,9 @@ docker = ">=5.0.3"
 typing_extensions = ">=3.7.4"
 
 [tool.poetry.dev-dependencies]
-flake8 = ">=3.7.7"
+flake8 = "^5.0.4"
 toml = ">=0.10"
-isort = ">=5.3"
+isort = "^5.11"
 pytest-cov = ">=2.7.1"
 black = "^22.8.0"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 addopts =
     --disable-pytest-warnings
-    --strict
+    --strict-markers
+    --strict-config
+    --pythonwarnings error
     --quiet
     --no-cov-on-fail

--- a/pytest_hoverfly/base.py
+++ b/pytest_hoverfly/base.py
@@ -73,7 +73,7 @@ def get_container(
     container_name: t.Optional[str] = None,
     ports: t.Optional[t.Dict[str, t.Optional[t.List[t.Dict[str, int]]]]] = None,
     image: str = IMAGE,
-    timeout: float = 30.0,
+    timeout: float = 3.0,
     docker_factory: t.Callable[[], DockerClient] = DockerClient.from_env,
     create_container_kwargs: t.Optional[t.Mapping[str, t.Any]] = None,
 ):

--- a/pytest_hoverfly/base.py
+++ b/pytest_hoverfly/base.py
@@ -73,7 +73,7 @@ def get_container(
     container_name: t.Optional[str] = None,
     ports: t.Optional[t.Dict[str, t.Optional[t.List[t.Dict[str, int]]]]] = None,
     image: str = IMAGE,
-    timeout: float = 3.0,
+    timeout: float = 30.0,
     docker_factory: t.Callable[[], DockerClient] = DockerClient.from_env,
     create_container_kwargs: t.Optional[t.Mapping[str, t.Any]] = None,
 ):

--- a/pytest_hoverfly/pytest_hoverfly.py
+++ b/pytest_hoverfly/pytest_hoverfly.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--hoverfly-start-timeout",
         dest="hoverfly_start_timeout",
-        default=30.0,
+        default=3.0,
         help=(
             "Timeout used while starting the container. "
             "It's used two times: waiting for ports to start accepting connections "

--- a/pytest_hoverfly/pytest_hoverfly.py
+++ b/pytest_hoverfly/pytest_hoverfly.py
@@ -60,6 +60,18 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
+        "--hoverfly-start-timeout",
+        dest="hoverfly_start_timeout",
+        default=30.0,
+        help=(
+            "Timeout used while starting the container. "
+            "It's used two times: waiting for ports to start accepting connections "
+            "and waiting for endpoints to start handling requests."
+        ),
+        type=float,
+    )
+
+    parser.addoption(
         "--hoverfly-args",
         dest="hoverfly_args",
         help="Arguments for hoverfly command. Passed as is.",
@@ -151,6 +163,7 @@ def hoverfly_instance(request) -> Hoverfly:
     yield from get_container(
         create_container_kwargs={"command": request.config.option.hoverfly_args},
         image=request.config.option.hoverfly_image,
+        timeout=request.config.option.hoverfly_start_timeout,
     )
 
 

--- a/tests/simulations/archive_org_simulation.json
+++ b/tests/simulations/archive_org_simulation.json
@@ -6,7 +6,7 @@
           "path": [
             {
               "matcher": "exact",
-              "value": "/version"
+              "value": "/metadata/SPD-SLRSY-1867/created"
             }
           ],
           "method": [
@@ -18,7 +18,7 @@
           "destination": [
             {
               "matcher": "exact",
-              "value": "foaas.com"
+              "value": "archive.org"
             }
           ],
           "scheme": [
@@ -40,12 +40,6 @@
                 "value": "application/json"
               }
             ],
-            "Accept-Encoding": [
-              {
-                "matcher": "exact",
-                "value": "gzip, deflate"
-              }
-            ],
             "Connection": [
               {
                 "matcher": "exact",
@@ -56,63 +50,35 @@
         },
         "response": {
           "status": 200,
-          "body": "{\"message\":\"Version 2.1.1\",\"subtitle\":\"FOAAS\"}",
+          "body": "{\"result\":1674991955}",
           "encodedBody": false,
           "headers": {
-            "Access-Control-Allow-Headers": [
-              "Content-Type"
-            ],
-            "Access-Control-Allow-Methods": [
-              "GET, OPTIONS"
-            ],
             "Access-Control-Allow-Origin": [
               "*"
-            ],
-            "Cf-Cache-Status": [
-              "DYNAMIC"
-            ],
-            "Cf-Ray": [
-              "56320068ca6acdb7-CDG"
             ],
             "Connection": [
               "keep-alive"
             ],
-            "Content-Length": [
-              "46"
-            ],
             "Content-Type": [
-              "application/json; charset=utf-8"
+              "application/json"
             ],
             "Date": [
-              "Mon, 10 Feb 2020 23:53:17 GMT"
-            ],
-            "Etag": [
-              "W/\"2e-QOrjR0GvSxG4LYg1O8wYFO7HqmM\""
-            ],
-            "Expect-Ct": [
-              "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""
+              "Sun, 29 Jan 2023 14:47:47 GMT"
             ],
             "Hoverfly": [
               "Was-Here"
             ],
-            "Server": [
-              "cloudflare"
+            "Referrer-Policy": [
+              "no-referrer-when-downgrade"
             ],
-            "Set-Cookie": [
-              "__cfduid=d090b33a06108864d458742671e3766ec1581378796; expires=Wed, 11-Mar-20 23:53:16 GMT; path=/; domain=.foaas.com; HttpOnly; SameSite=Lax",
-              "i18next=dev; path=/; expires=Wed, 10 Feb 2021 23:53:17 GMT"
+            "Server": [
+              "nginx/1.18.0 (Ubuntu)"
+            ],
+            "Strict-Transport-Security": [
+              "max-age=15724800"
             ],
             "Vary": [
               "Accept-Encoding"
-            ],
-            "Via": [
-              "1.1 vegur"
-            ],
-            "X-Clacks-Overhead": [
-              "GNU Terry Pratchett"
-            ],
-            "X-Content-Type-Options": [
-              "nosniff"
             ]
           },
           "templated": false
@@ -125,8 +91,8 @@
     }
   },
   "meta": {
-    "schemaVersion": "v5",
-    "hoverflyVersion": "v1.1.4",
-    "timeExported": "2020-02-10T23:53:17Z"
+    "schemaVersion": "v5.1",
+    "hoverflyVersion": "v1.3.7",
+    "timeExported": "2023-01-29T14:47:47Z"
   }
 }

--- a/tests/simulations/archive_org_simulation.json
+++ b/tests/simulations/archive_org_simulation.json
@@ -6,7 +6,7 @@
           "path": [
             {
               "matcher": "exact",
-              "value": "/metadata/SPD-SLRSY-1867/created"
+              "value": "/metadata/SPD-SLRSY-1867/metadata/identifier"
             }
           ],
           "method": [
@@ -50,7 +50,7 @@
         },
         "response": {
           "status": 200,
-          "body": "{\"result\":1674991955}",
+          "body": "{\"result\":\"SPD-SLRSY-1867\"}",
           "encodedBody": false,
           "headers": {
             "Access-Control-Allow-Origin": [

--- a/tests/test_pytest_hoverfly.py
+++ b/tests/test_pytest_hoverfly.py
@@ -31,11 +31,11 @@ from pytest_hoverfly import hoverfly
 @hoverfly('archive_org_simulation')
 def test_simulation_replayer():
     resp = requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={'Accept': 'application/json'},
     )
 
-    assert resp.json() == {"result": 1674991955}
+    assert resp.json() == {"result": "SPD-SLRSY-1867"}
 
     # Hoverfly adds Hoverfly: Was-Here header
     assert 'Hoverfly' in resp.headers
@@ -60,11 +60,11 @@ from pytest_hoverfly import hoverfly
 @hoverfly(name='archive_org_simulation')
 def test_simulation_replayer():
     resp = requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={'Accept': 'application/json'},
     )
 
-    assert resp.json() == {"result": 1674991955}
+    assert resp.json() == {"result": "SPD-SLRSY-1867"}
 
     # Hoverfly adds Hoverfly: Was-Here header
     assert 'Hoverfly' in resp.headers
@@ -108,7 +108,7 @@ from pytest_hoverfly import hoverfly
 @hoverfly('archive_org_simulation', record=True)
 def test_stateful_simulation_recorder():
     resp = requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={
             'Accept': 'application/json',
             # If we do not add it, hoverlfy would save encoded body, which is harder to verify.
@@ -116,7 +116,7 @@ def test_stateful_simulation_recorder():
         },
     )
 
-    assert resp.json() == {"result": 1674991955}
+    assert resp.json() == {"result": "SPD-SLRSY-1867"}
     """
     )
 
@@ -129,7 +129,7 @@ def test_stateful_simulation_recorder():
         simulation = json.load(f)
 
     assert len(simulation["data"]["pairs"]) == 1
-    assert "1674991955" in simulation["data"]["pairs"][0]["response"]["body"]
+    assert "SPD-SLRSY-1867" in simulation["data"]["pairs"][0]["response"]["body"]
 
 
 def test_hoverfly_decorator_stateful_recorder(testdir, tmpdir):
@@ -143,17 +143,17 @@ from pytest_hoverfly import hoverfly
 @hoverfly('archive_org_simulation', record=True, stateful=True)
 def test_stateful_simulation_recorder():
     requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={'Accept': 'application/json'},
 
     )
 
     resp = requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={'Accept': 'application/json'},
     )
 
-    assert resp.json() == {"result": 1674991955}
+    assert resp.json() == {"result": "SPD-SLRSY-1867"}
     """
     )
 
@@ -182,10 +182,12 @@ def test_lack_of_unintended_side_effects():
 
     This test hits a network!
     """
-    resp = requests.get("https://archive.org/metadata/SPD-SLRSY-1867/created", headers={"Accept": "application/json"})
+    resp = requests.get(
+        "https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier", headers={"Accept": "application/json"}
+    )
 
     try:
-        assert resp.json() == {"result": 1674991955}, resp.text
+        assert resp.json() == {"result": "SPD-SLRSY-1867"}, resp.text
     except json.decoder.JSONDecodeError:
         pytest.fail(resp.text + "\n\n(Request went to Hoverfly insted of archive.org)")
 
@@ -209,11 +211,11 @@ from pytest_hoverfly import hoverfly
 @hoverfly(name='archive_org_simulation')
 def test_timeout_parsing(request):
     resp = requests.get(
-        'https://archive.org/metadata/SPD-SLRSY-1867/created',
+        'https://archive.org/metadata/SPD-SLRSY-1867/metadata/identifier',
         headers={'Accept': 'application/json'},
     )
 
-    assert resp.json() == {"result": 1674991955}
+    assert resp.json() == {"result": "SPD-SLRSY-1867"}
 
     # Hoverfly adds Hoverfly: Was-Here header
     assert 'Hoverfly' in resp.headers


### PR DESCRIPTION
- Allow specifying hoverfly startup timeout
- Increased default hoverfly startup timeout

Previous default value (3s) was not enough for laptops with Apple silicon.
Had to rewrite tests because old testing API does not work anymore.

Github CI passed in my fork.